### PR TITLE
add portable feature

### DIFF
--- a/dist/main.js
+++ b/dist/main.js
@@ -8,6 +8,12 @@ const { download } = require('electron-dl');
 var mainWindow = null;
 var appIcon = null;
 
+// support for portable mode
+app.setPath('userData',
+  fs.existsSync(path.join(path.dirname(process.execPath),
+  '.portable')) == true ?  path.join(path.dirname(process.execPath),
+  'userdata') : app.getPath("userData") );
+
 var shouldQuit = app.makeSingleInstance(function(commandLine, workingDirectory) {
 	// someone tried to run a second instance, we should focus our window.
 	if (mainWindow) {

--- a/src/js/utils/settings.js
+++ b/src/js/utils/settings.js
@@ -11,10 +11,10 @@ var settings_filename = 'pilemdConfig.json';
 var settings_path;
 
 module.exports = {
-	init(filename) {
+    init(filename) {
 		if (filename) settings_filename = filename;
-		settings_path = path.join(elosenv.appDataPath(), settings_filename);
-		if (!fs.existsSync(settings_path)) settings_path = path.join(elosenv.appDataPath(), settings_filename);
+		settings_path = path.join(remote.app.getPath("userData"), settings_filename);
+		if (!fs.existsSync(settings_path)) settings_path = path.join(remote.app.getPath("userData"), settings_filename);
 
 		try {
 			settings_data = JSON.parse(fs.readFileSync(settings_path));


### PR DESCRIPTION
Support for running pilemd in a portable fashion so all data storage is in a ./userdata directory under the main application.

Portable mode is triggered by adding a '.portable' file to the application directory